### PR TITLE
fix: Update file path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ provided on the kubernetes clusters.
 The resources will be input in the default namespace location
 for the current user:
 
-`~/.local/share/skupper/namespaces/default/input/sources/`
+`~/.local/share/skupper/namespaces/default/input/resources/`
 
 _**Podman West:**_
 
@@ -280,7 +280,7 @@ _**West:**_
 
 ~~~ shell
 skupper token issue ~/link-to-west.yaml --redemptions-allowed 2
-skupper token issue ~/.local/share/skupper/namespaces/default/input/sources/link-to-west.yaml
+skupper token issue ~/.local/share/skupper/namespaces/default/input/resources/link-to-west.yaml
 ~~~
 
 _**East:**_
@@ -301,12 +301,12 @@ skupper token redeem ~/link-to-east.yaml
 
 The skupper cli can be used to create a podman (non-kube) site
 that instatiates the set of resources in the
-`~/.local/share/skupper/namespaces/default/input/sources` directory.
+`~/.local/share/skupper/namespaces/default/input/resources` directory.
 
 _**Podman West:**_
 
 ~~~ shell
-skupper system setup --path ~/.local/share/skupper/namespaces/default/input/sources
+skupper system setup --path ~/.local/share/skupper/namespaces/default/input/resources
 ~~~
 
 ## Step 11: Use Redis command line interface to verify master status

--- a/skewer.yaml
+++ b/skewer.yaml
@@ -127,7 +127,7 @@ steps:
       The resources will be input in the default namespace location
       for the current user:
 
-      `~/.local/share/skupper/namespaces/default/input/sources/`
+      `~/.local/share/skupper/namespaces/default/input/resources/`
     commands:
       podman-west:
         - run: ./podman-crs/setup-resources.sh
@@ -142,7 +142,7 @@ steps:
     commands:
       west:
         - run: skupper token issue ~/link-to-west.yaml --redemptions-allowed 2
-        - run: skupper token issue ~/.local/share/skupper/namespaces/default/input/sources/link-to-west.yaml
+        - run: skupper token issue ~/.local/share/skupper/namespaces/default/input/resources/link-to-west.yaml
       east:
         - run: skupper token issue .~/link-to-east.yaml
         - run: skupper token redeem ~/link-to-west.yaml
@@ -153,10 +153,10 @@ steps:
     preamble: |
       The skupper cli can be used to create a podman (non-kube) site
       that instatiates the set of resources in the
-      `~/.local/share/skupper/namespaces/default/input/sources` directory.
+      `~/.local/share/skupper/namespaces/default/input/resources` directory.
     commands: 
       podman-west:
-        - run: skupper system setup --path ~/.local/share/skupper/namespaces/default/input/sources
+        - run: skupper system setup --path ~/.local/share/skupper/namespaces/default/input/resources
   - title: Use Redis command line interface to verify master status
     preamble: |
       Running the `redis-cli` from the podman-west site, attach to the Redis server


### PR DESCRIPTION

- **Motivation and Context:**
    - The file path in the README.md was incorrect and needed to be updated to reflect the actual location of the resources.

- **How Has This Been Tested:**
    - I have manually tested the skupper token issue and skupper system setup commands with the updated file path.

- **Types of Changes:**
    - Documentation change

- **Checklist:**
    - My code follows the style guidelines of this project
    - I have performed a self-review of my own code
    - I have commented my code, particularly in hard-to-understand areas
    - I have made corresponding changes to the documentation

---

**Changes Made:**
- Updated file path in the README.md to correct the location of the resources.
- Updated commands `skupper token issue` and `skupper system setup` to use the correct file path.

---

This pull request addresses the issue with the incorrect file path in the README.md and ensures that the skupper token commands and skupper system setup commands reference the actual location of the resources. This change will provide clarity to users following the setup guide.
