### PR TITLE
Update outdated setup instructions. Fixes issue #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ podman system service --time=0 unix://$XDG_RUNTIME_DIR/podman/podman.sock &
 _**West:**_
 
 ~~~ shell
-kubectl kustomize https://github.com/skupperproject/skupper/config/default/cluster/ | kubectl apply -f -
+kubectl apply -f https://skupper.io/install.yaml
 ~~~
 
 ## Step 5: Create your sites


### PR DESCRIPTION
There is a bug in step 4 documentation telling you to download from skupper from a website that no longer exists. This PR fixes that